### PR TITLE
Fix forked for more than two arguments.

### DIFF
--- a/srfi/165.scm
+++ b/srfi/165.scm
@@ -168,10 +168,9 @@
 (define (forked a . a*)
   (make-computation
    (lambda (compute)
-     (let ((copy (environment-copy (compute (ask)))))
-       (let loop ((a a) (a* a*))
-	 (if (null? a*)
-	     (compute a)
-	     (begin
-	       (compute (local (lambda (env) copy) a))
-	       (loop (car a*) (cdr a*)))))))))
+     (let loop ((a a) (a* a*))
+       (if (null? a*)
+	   (compute a)
+	   (begin
+	     (compute (local (lambda (env) (environment-copy env)) a))
+	     (loop (car a*) (cdr a*))))))))


### PR DESCRIPTION
A minor correction of the sample implementation.

In `(forked a b c)`, the specification says that each `a` and `b` receive fresh copies of the original environment. Without this fix, the code would execute `b` on the same copy, on which `a` had been executed.
