### PR TITLE
Second draft

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -22,12 +22,14 @@
 
 ((scheme-mode
   (eval progn
-	(put 'with 'scheme-indent-function 1)
-	(put 'with! 'scheme-indent-function 0)
-	(put 'fn 'scheme-indent-function 1)
-	(put 'sequence 'scheme-indent-function 0)
+	(put 'computation-with 'scheme-indent-function 1)
+	(put 'computation-with! 'scheme-indent-function 0)
+	(put 'computation-fn 'scheme-indent-function 1)
+	(put 'computation-each 'scheme-indent-function 0)
+	(put 'computation-bind 'scheme-indent-function 1)
+	(put 'computation-local 'scheme-indent-function 1)
 	(font-lock-add-keywords
 	 nil
-	 '(("(\\(with\\)\\>" 1 font-lock-keyword-face)
-	   ("(\\(with!\\)\\>" 1 font-lock-keyword-face)
-	   ("(\\(fn\\))\\>" 1 font-lock-keyword-face))))))
+	 '(("(\\(computation-with\\)\\>" 1 font-lock-keyword-face)
+	   ("(\\(computation-with!\\)\\>" 1 font-lock-keyword-face)
+	   ("(\\(computation-fn\\))\\>" 1 font-lock-keyword-face))))))

--- a/srfi-165.html
+++ b/srfi-165.html
@@ -206,8 +206,9 @@
     </p>
 
     <p>
-      Fresh environment variables are created by evaluating the
-      expression <code>(make-computation-environment-variable)</code>.
+      Fresh environment variables are created by invoking the
+      procedure <code>make-computation-environment-variable</code>.
+      Each environment variable has a default value.
     </p>
 
     <p>Environments can be extended non-destructively to new
@@ -234,12 +235,16 @@
 
     <h2>Environment procedures</h2>
 
-    <p><code>(make-computation-environment-variable)</code></p>
+    <p><code>(make-computation-environment-variable <var>name</var> <var>default</var>
+	<var>immutable?</var>)</code></p>
 
     <p>Returns a Scheme object that can be used as an <dfn>environment
-      variable</dfn>.  The type of the returned object is unspecified.  Each
-      invocation returns an environment different to any previously
-      returned environment variable.
+      variable</dfn>, whose default value is <var>default</var> and
+      which is immutable if <var>immutable?</var> is
+      not <code>#f</code>.  The symbol or string <var>name</var> is
+      solely for debugging purposes.  The type of the returned object
+      is unspecified.  Each invocation returns an environment variable
+      different to any previously returned environment variable.
     </p>
 
     <p><code>(make-computation-environment)</code></p>
@@ -253,7 +258,7 @@
 
     <p>If the variable <var>var</var> is bound to a value in the
     environment <var>env</var>, returns that value,
-    and <code>#f</code> otherwise.</p>
+    and the environment variable's default value otherwise.</p>
 
     <p><code>(computation-environment-update <var>env</var> <var>arg</var>
 	…)</code></p>
@@ -430,7 +435,7 @@
 
     <p>
       An unbound environment variable behaves as if was bound
-      to <code>#f</code>.
+      to its default value.
     </p>
 
     <p><code>(computation-with ((〈variable<sub>1</sub>〉 〈init<sub>1</sub>〉) …) 〈expr<sub>1</sub>〉 …
@@ -455,7 +460,7 @@
     <p><code>(computation-with! (〈variable<sub>1</sub>〉 〈init<sub>1</sub>〉) …)</code></p>
 
     <p>
-      Evaluates the expressions 〈variable<sub>1</sub>〉 … to
+      Evaluates the expressions 〈variable<sub>1</sub>〉 … to mutable
       environment variables <var>var<sub>1</sub></var> … and the
       expressions 〈init<sub>1</sub>〉 … to
       values <var>val<sub>1</sub></var> … in an unspecified order, and
@@ -471,7 +476,7 @@
     
     <p>This SRFI exports the
       identifier <code>default-computation</code>, which is bound to a
-      location holding an environment variable (as if created
+      location holding a mutable environment variable (as if created
       by <code>(make-computation-environment-variable)</code>) in the
       sense of this SRFI.  In each fresh computation
       environment, <code>default-computation</code> is initially
@@ -497,10 +502,14 @@
       predefined environment variables.
     <p>
 
-    <p><code>(define-computation-type 〈make-environment〉 〈run〉 〈variable〉 …)</code></p>
+    <p><code>(define-computation-type 〈make-environment〉 〈run〉 〈clause〉 …)</code></p>
 
     <p>This syntax may appear wherever other definitions may
-      appear. <code>〈make-environment〉</code>, <code>〈run〉</code>,
+      appear. Each <code>〈clause〉</code> is of the form <code>(〈variable〉 〈default〉)</code>,
+      <code>(〈variable〉 〈default〉 "immutable")</code>,
+      or <code>〈variable〉</code>.  The latter form is equivalent
+      to <code>(〈variable〉 #f)</code>.
+      <code>〈make-environment〉</code>, <code>〈run〉</code>,
       and each <code>〈variable〉</code> are identifiers.
     </p>
     
@@ -528,9 +537,13 @@
       </li>
       <li>
 	<p>
-	  Each <code>〈variable〉</code> is bound to a environment variable, which can only
-	  be used with a environment created by invoking the procedure
-	  bound to <code>〈make-environment〉</code>.
+	  Each <code>〈variable〉</code> is bound to a environment
+	  variable, which can only be used with a environment created
+	  by invoking the procedure bound
+	  to <code>〈make-environment〉</code>.  Its default value is
+	  the result of evaluating <code>〈default〉</code>.  The
+	  environment variable is immutable if the <code>(〈variable〉
+	  〈default〉 "immutable")</code> form is used.
 	</p>
       </li>
     </ul>

--- a/srfi-165.html
+++ b/srfi-165.html
@@ -457,14 +457,18 @@
 
     <p><code>default-computation</code></p>
 
-    <p>This SRFI predefines one environment
-      variable, <code>default-computation</code>, which is initially
-      unbound.  Whenever an object <var>computation</var> is to be
+    <p>This SRFI exports the
+      identifier <code>default-computation</code>, which is bound to a
+      location holding an environment variable (as if created
+      by <code>(make-computation-environment-variable)</code>) in the
+      sense of this SRFI.  In each fresh computation
+      environment, <code>default-computation</code> is initially
+      unbound.  Whenever a computation <var>computation</var> is to be
       executed on an environment and is neither a computation nor a
       procedure, the value to which <code>default-computation</code>
       is bound in the environment has to be a procedure, which is then
-      invoked on <var>computation</var> to return a
-      computation, which is then executed on the environment.
+      invoked on <var>computation</var> to return a computation, which
+      is then executed on the environment.
     </p>
 
     <h1>Implementation</h1>

--- a/srfi-165.html
+++ b/srfi-165.html
@@ -63,28 +63,8 @@
       </li>
       <li>
 	<p>
-	  This SRFI defines an interface on which SRFIs like SRFI 159
-	  are supposed to be built.  There is a conceptual difference
-	  between SRFI 159 and this SRFI, though.  The environment
-	  variables of SRFI 159 are raw symbols, which makes them easy
-	  to use in simple cases, but they do not respect lexical
-	  scope and are entirely unhygienic.  The environment
-	  variables of this SRFI are like the parameters objects of
-	  SRFI 39, which are lexically scoped and can participate in
-	  the name-spacing provided by R7RS's library system and in
-	  Scheme's macro hygiene.  We therefore recommend that SRFI
-	  159 be amended so that is based on the infrastructure of
-	  this SRFI and does not use raw symbols.</p>
-
-	<p>
-	  The alternative would be to allow also raw symbols as
-	  environment variables in this SRFI (and to change the syntax
-	  of <code>fn</code>, <code>with</code> and <code>with!</code>
-	  accordingly).  While this has the advantage of being
-	  compatible with SRFI 159 as written, it has the drawback that
-	  it encourages the use of raw symbols to denote environment
-	  variables, leading to non-composable computations and to
-	  leaking of internal implementation details.
+	  This SRFI refers to SRFI 166, which has not been published
+	  yet.
 	</p>
       </li>
     </ul>
@@ -92,14 +72,33 @@
     <h1>Rationale</h1>
 
     <p>The environment monad is useful whenever code has to be
-      suspended and executed at a later time (even several times) and
+      suspended and executed at a later time (even several times), and
       whenever code depends (implicitly) on bindings of variables in a
       shared environment.
     </p>
 
     <p>
-      SRFI 159 is a major use case of the environment monad and a good
-      example of the concept in practice.
+      SRFI 166, a forthcoming revision of the combinator formatting
+      SRFI 159, is a major use case of the environment monad and a
+      good example of the concept in practice.  The formatters in SRFI
+      166 are computations in the nomenclature of this SRFI.  In
+      particular, the properties for computations apply to formatters
+      as well and the primitive and the derived procedures of this
+      SRFI can be used to construct sophisticated formatters of SRFI
+      166.
+    </p>
+
+    <p>
+      Nonetheless, SRFI 165 is an independent SRFI and not a proper
+      part of SRFI 166 for two reasons: Firstly, the SRFI 166's
+      combinator formatters are just one use case for the environment
+      monad of SRFI 165, so one wants to be able to use the procedures
+      and syntax specified in this SRFI independently of
+      formatting. Secondly, this SRFI exports more primitive and
+      derived procedures for the environment monad and computations
+      than are usually needed to write simple SRFI 166 formatters, so
+      including them all in SRFI 166 would shift away the focus
+      of SRFI 166 too much from its genuine purpose, formatting.
     </p>
 
     <h2>Monads</h2>
@@ -178,7 +177,7 @@
       of <var>proc</var>.
     </p>
 
-    <p>Computations are executed by <code>run</code>.  The
+    <p>Computations are executed by <code>computation-run</code>.  The
       expression <code>(computation-run <var>computation</var>)</code>
       returns the values yielded by the execution
       of <var>computation</var>.
@@ -221,8 +220,9 @@
     </p>
 
     <p>
-      This SRFI provides the computation <code>(ask)</code>, which
-      yields the current environment.  Executing the
+      This SRFI provides the
+      computation <code>(computation-ask)</code>, which yields the
+      current environment.  Executing the
       computation <code>(computation-local <var>updater</var> <var>computation</var>)</code>
       on an environment <var>env</var> means
       executing <var>computation</var> on the
@@ -417,6 +417,13 @@
     </p>
 
     <p>
+      A <dfn>clause</dfn> of the form <code>(〈variable〉
+      〈variable〉)</code> (i.e. the <code>expression 〈init〉</code>
+      is the variable reference <code>〈variable〉</code>) can be
+      abbreviated by <code>〈variable〉</code>.
+    </p>
+
+    <p>
       An unbound environment variable behaves as if was bound
       to <code>#f</code>.
     </p>
@@ -471,6 +478,41 @@
       is then executed on the environment.
     </p>
 
+    <h2>Relation to other SRFIs</h2>
+
+    <p>
+      In a Scheme system supporting both SRFI 165 and SRFI 166, the
+      implementation of SRFI 166 shall be compatible with the
+      implementation of SRFI 165.  This means, in particular, the
+      following:
+    </p>
+
+    <ul>
+      <li>
+	<p>SRFI 166 formatters are SRFI 165 computations.  In
+	  particular, they yield values (often an undefined one) to
+	  support functional programming.  SRFI
+	  166's <code>show</code> executes the computations in a SRFI
+	  166 specific environment.
+	</p>
+      </li>
+      <li>
+	<p>
+	  The bindings of the
+	  identifiers <code>fn</code>, <code>with</code>, <code>with!</code>,
+	  <code>each</code>, <code>each-in-list</code>, <code>forked</code>,
+	  and <code>make-state-variable</code> of SRFI 166 are the same
+	  as the bindings
+	  of <code>computation-fn</code>, <code>computation-with</code>,
+	  <code>computation-with!</code>,
+	  <code>computation-each</code>, <code>computation-each-in-list</code>,
+	  <code>computation-forked</code>,
+	  and <code>make-computation-environment-variable</code> of SRFI 165,
+	  respectively.
+	</p>
+      </li>
+    </ul>
+
     <h1>Implementation</h1>
 
     <p>The sample implementation is coded in portable R7RS scheme.  It
@@ -502,6 +544,11 @@ Polymorphism</i>, Advanced School of Functional Programming, 1995.
       name <em>standard construction</em>.  They are also known
       as <em>triples</em>.  The term <em>monad</em> is due to Saunders
       Mac Lane.
+    </p>
+
+    <p>
+      The author of this SRFI wants to thank Alex Shinn and John
+      Cowan for their valuable comments during its draft period.
     </p>
 
     <h1>Copyright</h1>

--- a/srfi-165.html
+++ b/srfi-165.html
@@ -151,7 +151,7 @@
     <p>
       This SRFI provides a number of combinators that combine
       computations.  For
-      example <code>(sequence <var>computation<sub>1</sub></var>
+      example <code>(each <var>computation<sub>1</sub></var>
       … <var>computation<sub>n</sub></var>)</code> is the computation
       formed by applying each <var>computation<sub>1</sub></var>,
       …, <var>computation<sub>n</sub></var> in sequence and eventually
@@ -320,7 +320,7 @@
       values <var>obj<sub>1</sub></var> ….
     </p>
 
-    <p><code>(sequence <var>computation<sub>1</sub></var>
+    <p><code>(each <var>computation<sub>1</sub></var>
 	… <var>computation<sub>n</sub></var>)</code></p>
 
     <p>

--- a/srfi-165.html
+++ b/srfi-165.html
@@ -330,6 +330,16 @@
       yielded by the last computation.
     </p>
 
+    <p><code>(each-in-list <var>list</var>)</code></p>
+
+    <p>
+      Equivalent to <code>(each <var>computation<sub>1</sub></var>
+	… <var>computation<sub>n</sub></var>)</code>
+	if <var>list</var> is a list whose elements
+	are <var>computation<sub>1</sub></var>,
+	…, <var>computation<sub>n</sub></var>.
+    </p>
+
     <p><code>(bind <var>computation</var> <var>proc<sub>1</sub></var> …)</code></p>
 
     <p>

--- a/srfi-165.html
+++ b/srfi-165.html
@@ -143,7 +143,7 @@
     </p>
 
     <p>
-      The simplest computation is <code>(return <var>val<sub>1</sub>
+      The simplest computation is <code>(pure <var>val<sub>1</sub>
 	  …)</code>, which just yields the
 	  results <var>val<sub>1</sub></var> … when executed.
     </p>
@@ -313,7 +313,7 @@
 
     <h2>Derived monadic procedures</h2>
 
-    <p><code>(return <var>obj<sub>1</sub></var> …)</code></p>
+    <p><code>(pure <var>obj<sub>1</sub></var> …)</code></p>
 
     <p>
       Returns a computation that, when executed, yields the
@@ -426,7 +426,7 @@
       invoked on <var>computation</var> to return a
       computation, which is then executed on the environment.
     </p>
-    
+
     <h1>Implementation</h1>
 
     <p>The sample implementation is coded in portable R7RS scheme.  It

--- a/srfi-165.html
+++ b/srfi-165.html
@@ -63,8 +63,9 @@
       </li>
       <li>
 	<p>
-	  This SRFI refers to SRFI 166, which has not been published
-	  yet.
+	  SRFI 165 and SRFI 166 shall be in line with each other,
+	  which may not be completely the case while they are still in
+	  draft status.
 	</p>
       </li>
     </ul>
@@ -463,7 +464,7 @@
     <h2>Environment variables</h2>
 
     <p><code>default-computation</code></p>
-
+    
     <p>This SRFI exports the
       identifier <code>default-computation</code>, which is bound to a
       location holding an environment variable (as if created
@@ -478,6 +479,58 @@
       is then executed on the environment.
     </p>
 
+    <h2>Extension for predefined environment variables</h2>
+
+    <p>
+      The complexity for accessing environment variables is
+      O(<var>n</var>) where <var>n</var> is the number of variables
+      bound in the environment.
+    </p>
+
+    <p>In use cases, where a few environment variables are accessed
+      often and which can be defined statically, the following syntax
+      can be used, which guarantees an accessing time of O(1) for
+      predefined environment variables.
+    <p>
+
+    <p><code>(define-computation-type 〈make-environment〉 〈run〉 〈variable〉 …)</code></p>
+
+    <p>This syntax may appear wherever other definitions may
+      appear. <code>〈make-environment〉</code>, <code>〈run〉</code>,
+      and each <code>〈variable〉</code> are identifiers.
+    </p>
+    
+    <p>
+      An instance of <code>define-computation-type</code> is equivalent
+      to the following definitions:
+    </p>
+
+    <ul>
+      <li>
+	<p><code>〈make-environment〉</code> is bound to a procedure that takes no
+	  arguments.  Invoking the procedure is equivalent to
+	  invoking <code>make-computation-environment</code> except for
+	  that the environment variables defined below can be used with
+	  the resulting environment.
+	</p>
+      </li>
+      <li>
+	<p><code>〈run〉</code> is bound to a procedure that takes one argument.
+	  Invoking the procedure is equivalent to
+	  invoking <code>computation-run</code> except for that the
+	  initial environment is created by invoking the procedure bound
+	  to <code>〈make-environment〉</code>.
+	</p>
+      </li>
+      <li>
+	<p>
+	  Each <code>〈variable〉</code> is bound to a environment variable, which can only
+	  be used with a environment created by invoking the procedure
+	  bound to <code>〈make-environment〉</code>.
+	</p>
+      </li>
+    </ul>
+    
     <h2>Relation to other SRFIs</h2>
 
     <p>

--- a/srfi-165.html
+++ b/srfi-165.html
@@ -359,6 +359,17 @@
       a computation, which is then executed and which results are yielded.
     </p>
 
+    <p>
+      <code>(sequence <var>list</var>)</code>
+    </p>
+
+    <p>
+      When invoked on a list <var>list</var> of computations, returns
+      a computation that, when executed, executes the computations in
+      sequence and yields a list whose elements are the results
+      yielded by the computations.
+    </p>
+
     <p><code>(forked <var>computation<sub>1</sub></var>
 	… <var>computation<sub>n</sub></var>)</code></p>
 
@@ -448,8 +459,8 @@
     <h1>Implementation</h1>
 
     <p>The sample implementation is coded in portable R7RS scheme.  It
-      makes use of the (portable) SRFI 111, SRFI 125, SRFI 128, and
-      SRFI 146.  The testing code also uses SRFI 64.
+      makes use of the (portable) SRFI 1, SRFI 111, SRFI 125, SRFI
+      128, and SRFI 146.  The testing code also uses SRFI 64.
     </p>
 
     <p>

--- a/srfi-165.html
+++ b/srfi-165.html
@@ -371,6 +371,14 @@
       environment and yields its results.
     </p>
 
+    <p><code>(bind/forked <var>computation</var> <var>proc<sub>1</sub></var> …)</code></p>
+
+    <p>
+      As <code>(bind <var>computation</var> <var>proc<sub>1</sub></var>
+      …)</code>, but executes <var>computation</var> on a fresh copy
+      of the environment.
+    </p>
+
     <h2>Derived syntax</h2>
 
     <p><code>(fn ((〈variable<sub>1</sub>〉 〈init<sub>1</sub>〉) …) 〈body〉)</code></p>

--- a/srfi-165.html
+++ b/srfi-165.html
@@ -255,12 +255,16 @@
     environment <var>env</var>, returns that value,
     and <code>#f</code> otherwise.</p>
 
-    <p><code>(computation-environment-update <var>env</var> <var>var</var> <var>val</var>)</code></p>
-
-    <p>Returns a new environment that extends the
-      environment <var>env</var> by binding the
+    <p><code>(computation-environment-update <var>env</var> <var>arg</var>
+	…)</code></p>
+    
+    <p>
+      The arguments <var>arg</var> … alter between environment
+      variables <var>var</var> and values <var>val</var>.
+      Returns a new environment that extends the
+      environment <var>env</var> by binding each
       environment variable <var>var</var>
-      to <var>val</var>.
+      to the respective value <var>val</var>.
     </p>
 
     <p><code>(computation-environment-update! <var>env</var> <var>var</var> <var>val</var>)</code></p>
@@ -418,8 +422,8 @@
     </p>
 
     <p>
-      A <dfn>clause</dfn> of the form <code>(〈variable〉
-      〈variable〉)</code> (i.e. the <code>expression 〈init〉</code>
+      A <dfn>clause</dfn> of the form <code>(〈variable〉 〈variable〉)</code>
+      (i.e. the <code>expression 〈init〉</code>
       is the variable reference <code>〈variable〉</code>) can be
       abbreviated by <code>〈variable〉</code>.
     </p>

--- a/srfi-165.html
+++ b/srfi-165.html
@@ -20,7 +20,16 @@
 
     <h1>Status</h1>
 
-    <p>This SRFI is currently in <em>draft</em> status.  Here is <a href="https://srfi.schemers.org/srfi-process.html">an explanation</a> of each status that a SRFI can hold.  To provide input on this SRFI, please send email to <code><a href="mailto:srfi+minus+165+at+srfi+dotschemers+dot+org">srfi-165@<span class="antispam">nospam</span>srfi.schemers.org</a></code>.  To subscribe to the list, follow <a href="https://srfi.schemers.org/srfi-list-subscribe.html">these instructions</a>.  You can access previous messages via the mailing list <a href="https://srfi-email.schemers.org/srfi-165">archive</a>.</p>
+    <p>This SRFI is currently in <em>draft</em> status.  Here
+    is <a href="https://srfi.schemers.org/srfi-process.html">an
+    explanation</a> of each status that a SRFI can hold.  To provide
+    input on this SRFI, please send email
+    to <code><a href="mailto:srfi+minus+165+at+srfi+dotschemers+dot+org">srfi-165@<span class="antispam">nospam</span>srfi.schemers.org</a></code>.
+    To subscribe to the list,
+    follow <a href="https://srfi.schemers.org/srfi-list-subscribe.html">these
+    instructions</a>.  You can access previous messages via the
+    mailing
+    list <a href="https://srfi-email.schemers.org/srfi-165">archive</a>.</p>
     <ul>
       <li>Received: 2019/2/13</li>
       <li>60-day deadline: 2019/4/14</li>
@@ -143,15 +152,16 @@
     </p>
 
     <p>
-      The simplest computation is <code>(pure <var>val<sub>1</sub>
-	  …)</code>, which just yields the
-	  results <var>val<sub>1</sub></var> … when executed.
+      The simplest computation
+      is <code>(computation-pure <var>val<sub>1</sub> …)</code>,
+      which just yields the results <var>val<sub>1</sub></var> …
+      when executed.
     </p>
 
     <p>
       This SRFI provides a number of combinators that combine
       computations.  For
-      example <code>(each <var>computation<sub>1</sub></var>
+      example <code>(computation-each <var>computation<sub>1</sub></var>
       … <var>computation<sub>n</sub></var>)</code> is the computation
       formed by applying each <var>computation<sub>1</sub></var>,
       …, <var>computation<sub>n</sub></var> in sequence and eventually
@@ -161,7 +171,7 @@
     <p>
       Another combinator known from monads in functional programming
       is the computation
-      <code>(bind <var>computation</var> <var>proc</var>)</code>,
+      <code>(computation-bind <var>computation</var> <var>proc</var>)</code>,
       which is the computation formed by feeding the results yielded
       by <var>computation</var> to <var>proc</var> and yielding the
       results of the computation returned by the invocation
@@ -169,8 +179,9 @@
     </p>
 
     <p>Computations are executed by <code>run</code>.  The
-      expression <code>(run <var>computation</var>)</code> returns the
-      values yielded by the execution of <var>computation</var>.
+      expression <code>(computation-run <var>computation</var>)</code>
+      returns the values yielded by the execution
+      of <var>computation</var>.
     </p>
 
     <p>The primary constructor for computations
@@ -196,7 +207,7 @@
 
     <p>
       Fresh environment variables are created by evaluating the
-      expression <code>(make-environment-variable)</code>.
+      expression <code>(make-computation-environment-variable)</code>.
     </p>
 
     <p>Environments can be extended non-destructively to new
@@ -205,14 +216,14 @@
     </p>
 
     <p>
-      The <code>run</code> procedure creates a new empty environment
+      The <code>computation-run</code> procedure creates a new empty environment
       that is then threaded through the computation.
     </p>
 
     <p>
       This SRFI provides the computation <code>(ask)</code>, which
       yields the current environment.  Executing the
-      computation <code>(local <var>updater</var> <var>computation</var>)</code>
+      computation <code>(computation-local <var>updater</var> <var>computation</var>)</code>
       on an environment <var>env</var> means
       executing <var>computation</var> on the
       environment <code>(<var>updater</var> env)</code>.
@@ -222,7 +233,7 @@
 
     <h2>Environment procedures</h2>
 
-    <p><code>(make-environment-variable)</code></p>
+    <p><code>(make-computation-environment-variable)</code></p>
 
     <p>Returns a Scheme object that can be used as an <dfn>environment
       variable</dfn>.  The type of the returned object is unspecified.  Each
@@ -230,20 +241,20 @@
       returned environment variable.
     </p>
 
-    <p><code>(make-environment)</code></p>
+    <p><code>(make-computation-environment)</code></p>
 
     <p>Returns a new <dfn>environment</dfn>, in which environment
       variables can be bound to values.  The type of the returned
       object is unspecified.
     </p>
 
-    <p><code>(environment-ref <var>env</var> <var>var</var>)</code></p>
+    <p><code>(computation-environment-ref <var>env</var> <var>var</var>)</code></p>
 
     <p>If the variable <var>var</var> is bound to a value in the
     environment <var>env</var>, returns that value,
     and <code>#f</code> otherwise.</p>
 
-    <p><code>(environment-update <var>env</var> <var>var</var> <var>val</var>)</code></p>
+    <p><code>(computation-environment-update <var>env</var> <var>var</var> <var>val</var>)</code></p>
 
     <p>Returns a new environment that extends the
       environment <var>env</var> by binding the
@@ -251,16 +262,16 @@
       to <var>val</var>.
     </p>
 
-    <p><code>(environment-update! <var>env</var> <var>var</var> <var>val</var>)</code></p>
+    <p><code>(computation-environment-update! <var>env</var> <var>var</var> <var>val</var>)</code></p>
 
     <p>Updates the environment <var>env</var> in place by
       binding the environment variable <var>var</var>
       to <var>val</var>, and returns an unspecified value.
     </p>
 
-    <p><code>(environment-copy <var>env</var>)</code></p>
+    <p><code>(computation-environment-copy <var>env</var>)</code></p>
 
-    <p>Returns a new copy of the
+    <p>Returns a fresh copy of the
       environment <var>env</var>.
     </p>
 
@@ -286,21 +297,21 @@
       of the invocation of <var>proc</var>.
     </p>
 
-    <p><code>(run <var>computation</var>)</code></p>
+    <p><code>(computation-run <var>computation</var>)</code></p>
 
     <p>
       Executes the computation <var>computation</var> and returns the
       results it yields.
     </p>
 
-    <p><code>(ask)</code></p>
+    <p><code>(computation-ask)</code></p>
 
     <p>
       Returns a computation that, when executed on an environment,
       yields that environment.
     </p>
 
-    <p><code>(local <var>updater</var> <var>computation</var>)</code></p>
+    <p><code>(computation-local <var>updater</var> <var>computation</var>)</code></p>
 
     <p>
       Returns a computation that, when executed on an
@@ -313,14 +324,14 @@
 
     <h2>Derived monadic procedures</h2>
 
-    <p><code>(pure <var>obj<sub>1</sub></var> …)</code></p>
+    <p><code>(computation-pure <var>obj<sub>1</sub></var> …)</code></p>
 
     <p>
       Returns a computation that, when executed, yields the
       values <var>obj<sub>1</sub></var> ….
     </p>
 
-    <p><code>(each <var>computation<sub>1</sub></var>
+    <p><code>(computation-each <var>computation<sub>1</sub></var>
 	… <var>computation<sub>n</sub></var>)</code></p>
 
     <p>
@@ -330,29 +341,29 @@
       yielded by the last computation.
     </p>
 
-    <p><code>(each-in-list <var>list</var>)</code></p>
+    <p><code>(computation-each-in-list <var>list</var>)</code></p>
 
     <p>
-      Equivalent to <code>(each <var>computation<sub>1</sub></var>
+      Equivalent to <code>(computation-each <var>computation<sub>1</sub></var>
 	… <var>computation<sub>n</sub></var>)</code>
 	if <var>list</var> is a list whose elements
 	are <var>computation<sub>1</sub></var>,
 	…, <var>computation<sub>n</sub></var>.
     </p>
 
-    <p><code>(bind <var>computation</var> <var>proc<sub>1</sub></var> …)</code></p>
+    <p><code>(computation-bind <var>computation</var> <var>proc<sub>1</sub></var> …)</code></p>
 
     <p>
-      <code>(bind <var>computation</var>)</code> is equivalent
-      to <var>computation</var>.  <code>(bind <var>computation</var>
+      <code>(computation-bind <var>computation</var>)</code> is equivalent
+      to <var>computation</var>.  <code>(computation-bind <var>computation</var>
 	<var>proc<sub>1</sub></var> <var>proc<sub>2</sub></var>
-	…)</code> is equivalent to <code>(bind
-	(bind <var>computation</var> <var>proc<sub>1</sub></var>)
+	…)</code> is equivalent to <code>(computation-bind
+	(computation-bind <var>computation</var> <var>proc<sub>1</sub></var>)
 	<var>proc<sub>2</sub></var> …)</code>.
     </p>
 
     <p>
-      The invocation of <code>(bind <var>computation</var> <var>proc</var>)</code>
+      The invocation of <code>(computation-bind <var>computation</var> <var>proc</var>)</code>
       returns a computation that, when executed, executes the
       computation <var>computation</var>, on which results the
       procedure <var>proc</var> is then invoked and that has to return
@@ -360,7 +371,7 @@
     </p>
 
     <p>
-      <code>(sequence <var>list</var>)</code>
+      <code>(computation-sequence <var>list</var>)</code>
     </p>
 
     <p>
@@ -370,7 +381,7 @@
       yielded by the computations.
     </p>
 
-    <p><code>(forked <var>computation<sub>1</sub></var>
+    <p><code>(computation-forked <var>computation<sub>1</sub></var>
 	… <var>computation<sub>n</sub></var>)</code></p>
 
     <p>
@@ -382,17 +393,17 @@
       environment and yields its results.
     </p>
 
-    <p><code>(bind/forked <var>computation</var> <var>proc<sub>1</sub></var> …)</code></p>
+    <p><code>(computation-bind/forked <var>computation</var> <var>proc<sub>1</sub></var> …)</code></p>
 
     <p>
-      As <code>(bind <var>computation</var> <var>proc<sub>1</sub></var>
+      As <code>(computation-bind <var>computation</var> <var>proc<sub>1</sub></var>
       …)</code>, but executes <var>computation</var> on a fresh copy
       of the environment.
     </p>
 
     <h2>Derived syntax</h2>
 
-    <p><code>(fn ((〈variable<sub>1</sub>〉 〈init<sub>1</sub>〉) …) 〈body〉)</code></p>
+    <p><code>(computation-fn ((〈variable<sub>1</sub>〉 〈init<sub>1</sub>〉) …) 〈body〉)</code></p>
 
     <p>
       Evaluates the expressions 〈init<sub>1</sub>〉 … to environment
@@ -410,7 +421,7 @@
       to <code>#f</code>.
     </p>
 
-    <p><code>(with ((〈variable<sub>1</sub>〉 〈init<sub>1</sub>〉) …) 〈expr<sub>1</sub>〉 …
+    <p><code>(computation-with ((〈variable<sub>1</sub>〉 〈init<sub>1</sub>〉) …) 〈expr<sub>1</sub>〉 …
 	〈expr<sub>n</sub>〉)</code></p>
     <p>
       Evaluates the expressions 〈expr<sub>1</sub>〉 …
@@ -429,7 +440,7 @@
       environment, and then yields the results of the last computation.
     </p>
 
-    <p><code>(with! (〈variable<sub>1</sub>〉 〈init<sub>1</sub>〉) …)</code></p>
+    <p><code>(computation-with! (〈variable<sub>1</sub>〉 〈init<sub>1</sub>〉) …)</code></p>
 
     <p>
       Evaluates the expressions 〈variable<sub>1</sub>〉 … to

--- a/srfi/165.scm
+++ b/srfi/165.scm
@@ -182,3 +182,12 @@
   (apply bind
 	 (local environment-copy computation)
 	 proc*))
+
+(define (sequence fmt*)
+  (fold-right (lambda (fmt res)
+		(bind res
+		  (lambda (vals)
+		    (bind fmt
+		      (lambda (val)
+			(pure (cons val vals)))))))
+	      (pure '()) fmt*))

--- a/srfi/165.scm
+++ b/srfi/165.scm
@@ -87,7 +87,7 @@
    (lambda (compute)
      (apply values args))))
 
-(define (sequence a . a*)
+(define (each a . a*)
   (make-computation
    (lambda (compute)
      (let loop ((a a) (a* a*))
@@ -144,7 +144,7 @@
        (local (lambda (env)
 		(let* ((env (environment-update env u v)) ...)
 		  env))
-	 (sequence b ...))))
+	 (each b ...))))
     ((_ ((var val) . rest) (p ...) () a* ...)
      (%with rest (p ... (var u val v)) () a* ...))
     ((_ () p* (q ...) a . a*)

--- a/srfi/165.scm
+++ b/srfi/165.scm
@@ -82,7 +82,7 @@
 (define (run computation)
   (execute computation (make-environment)))
 
-(define (return . args)
+(define (pure . args)
   (make-computation
    (lambda (compute)
      (apply values args))))
@@ -161,7 +161,7 @@
      (let ((u var) ... (v val) ...)
        (bind (ask) (lambda (env)
 		     (environment-update! env u v) ...
-		     (return (if #f #f))))))
+		     (pure (if #f #f))))))
     ((_ (var val) r ... (p ...))
      (%with! r ... (p ... (var u val v))))))
 

--- a/srfi/165.scm
+++ b/srfi/165.scm
@@ -177,3 +177,8 @@
 	   (begin
 	     (compute (local (lambda (env) (environment-copy env)) a))
 	     (loop (car a*) (cdr a*))))))))
+
+(define (bind/forked computation . proc*)
+  (apply bind
+	 (local environment-copy computation)
+	 proc*))

--- a/srfi/165.scm
+++ b/srfi/165.scm
@@ -88,9 +88,12 @@
      (apply values args))))
 
 (define (each a . a*)
-  (make-computation
+  (each-in-list (cons a a*)))
+
+(define (each-in-list a*)
+ (make-computation
    (lambda (compute)
-     (let loop ((a a) (a* a*))
+     (let loop ((a (car a*)) (a* (cdr a*)))
        (if (null? a*)
 	   (compute a)
 	   (begin

--- a/srfi/165.scm
+++ b/srfi/165.scm
@@ -124,8 +124,8 @@
 
 (define-syntax computation-fn
   (syntax-rules ()
-    ((_ ((id var) ...) expr ... computation)
-     (%fn ((id var) ...) () expr ... computation))))
+    ((_ (clause ...) expr ... computation)
+     (%fn (clause ...) () expr ... computation))))
 
 (define-syntax %fn
   (syntax-rules ()
@@ -137,7 +137,9 @@
 	     expr ...
 	     computation)))))
     ((_ ((id var) . rest) (p ...) expr ... computation)
-     (%fn rest (p ... (id var tmp)) expr ... computation))))
+     (%fn rest (p ... (id var tmp)) expr ... computation))
+    ((_ (id . rest) (p ...) expr ... computation)
+     (%fn rest (p ... (id id tmp)) expr ... computation))))
 
 (define-syntax computation-with
   (syntax-rules ()

--- a/srfi/165.sld
+++ b/srfi/165.sld
@@ -24,7 +24,7 @@
   (export make-environment-variable
 	  make-environment environment-ref environment-update
 	  environment-update! environment-copy
-	  make-computation each pure bind run ask local
+	  make-computation each each-in-list pure bind run ask local
 	  fn with with! forked
 	  default-computation)
   (import (scheme base)

--- a/srfi/165.sld
+++ b/srfi/165.sld
@@ -21,11 +21,15 @@
 ;; SOFTWARE.
 
 (define-library (srfi 165)
-  (export make-environment-variable
-	  make-environment environment-ref environment-update
-	  environment-update! environment-copy
-	  make-computation each each-in-list pure bind sequence run ask local
-	  fn with with! forked bind/forked
+  (export make-computation-environment-variable
+	  make-computation-environment computation-environment-ref
+	  computation-environment-update
+	  computation-environment-update! computation-environment-copy
+	  make-computation computation-each computation-each-in-list
+	  computation-pure computation-bind computation-sequence
+	  computation-run computation-ask computation-local
+	  computation-fn computation-with computation-with!
+	  computation-forked computation-bind/forked
 	  default-computation)
   (import (scheme base)
 	  (srfi 1)

--- a/srfi/165.sld
+++ b/srfi/165.sld
@@ -25,7 +25,7 @@
 	  make-environment environment-ref environment-update
 	  environment-update! environment-copy
 	  make-computation each each-in-list pure bind run ask local
-	  fn with with! forked
+	  fn with with! forked bind/forked
 	  default-computation)
   (import (scheme base)
 	  (srfi 111)

--- a/srfi/165.sld
+++ b/srfi/165.sld
@@ -24,7 +24,7 @@
   (export make-environment-variable
 	  make-environment environment-ref environment-update
 	  environment-update! environment-copy
-	  make-computation pure sequence bind run ask local
+	  make-computation each pure bind run ask local
 	  fn with with! forked
 	  default-computation)
   (import (scheme base)

--- a/srfi/165.sld
+++ b/srfi/165.sld
@@ -24,7 +24,7 @@
   (export make-environment-variable
 	  make-environment environment-ref environment-update
 	  environment-update! environment-copy
-	  make-computation return sequence bind run ask local
+	  make-computation pure sequence bind run ask local
 	  fn with with! forked
 	  default-computation)
   (import (scheme base)

--- a/srfi/165.sld
+++ b/srfi/165.sld
@@ -30,7 +30,8 @@
 	  computation-run computation-ask computation-local
 	  computation-fn computation-with computation-with!
 	  computation-forked computation-bind/forked
-	  default-computation)
+	  default-computation
+	  define-computation-type)
   (import (scheme base)
 	  (srfi 1)
 	  (srfi 111)

--- a/srfi/165.sld
+++ b/srfi/165.sld
@@ -24,10 +24,11 @@
   (export make-environment-variable
 	  make-environment environment-ref environment-update
 	  environment-update! environment-copy
-	  make-computation each each-in-list pure bind run ask local
+	  make-computation each each-in-list pure bind sequence run ask local
 	  fn with with! forked bind/forked
 	  default-computation)
   (import (scheme base)
+	  (srfi 1)
 	  (srfi 111)
 	  (srfi 125)
 	  (srfi 128)

--- a/srfi/165/test.sld
+++ b/srfi/165/test.sld
@@ -178,6 +178,12 @@
 			     (computation-fn ((y x))
 			       (computation-pure y))))))
 
+      (test-eqv 42
+	(let ((x (make-computation-environment-variable)))
+	  (computation-run (computation-with ((x 42))
+			     (computation-fn (x)
+			       (computation-pure x))))))
+
       (test-eqv #f
 	(let ((x (make-computation-environment-variable)))
 	  (computation-run (computation-each (computation-with ((x 42))

--- a/srfi/165/test.sld
+++ b/srfi/165/test.sld
@@ -2,22 +2,23 @@
 
 ;; Permission is hereby granted, free of charge, to any person
 ;; obtaining a copy of this software and associated documentation
-;; files (the "Software"), to deal in the Software without
-;; restriction, including without limitation the rights to use, copy,
-;; modify, merge, publish, distribute, sublicense, and/or sell copies
-;; of the Software, and to permit persons to whom the Software is
-;; furnished to do so, subject to the following conditions:
+;; files (the "Software"), to deal in the Software computation-without
+;; restriction, including computation-without limitation the rights to
+;; use, copy, modify, merge, publish, distribute, sublicense, and/or
+;; sell copies of the Software, and to permit persons to whom the
+;; Software is furnished to do so, subject to the following
+;; conditions:
 
 ;; The above copyright notice and this permission notice shall be
 ;; included in all copies or substantial portions of the Software.
 
-;; THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+;; THE SOFTWARE IS PROVIDED "AS IS", COMPUTATION-WITHOUT WARRANTY OF ANY KIND,
 ;; EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 ;; MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
 ;; NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
 ;; BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
 ;; ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-;; CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+;; CONNECTION COMPUTATION-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 ;; SOFTWARE.
 
 (define-library (srfi 165 test)
@@ -29,64 +30,69 @@
     (define (run-tests)
       (test-begin "SRFI 165")
 
-      (test-assert (not (eqv? (make-environment-variable)
-			      (make-environment-variable))))
+      (test-assert (not (eqv? (make-computation-environment-variable)
+			      (make-computation-environment-variable))))
 
-      (test-assert (make-environment))
-
-      (test-eqv #f
-	(let ((x (make-environment-variable)))
-	  (environment-ref (make-environment) x)))
-
-      (test-eqv 42
-	(let ((x (make-environment-variable)))
-	  (environment-ref (environment-update (make-environment) x 42)
-			   x)))
+      (test-assert (make-computation-environment))
 
       (test-eqv #f
-	(let ((x (make-environment-variable))
-	      (y (make-environment-variable)))
-	  (environment-ref (environment-update (make-environment) x 42)
-			   y)))
+	(let ((x (make-computation-environment-variable)))
+	  (computation-environment-ref (make-computation-environment) x)))
+
+      (test-eqv 42
+	(let ((x (make-computation-environment-variable)))
+	  (computation-environment-ref
+	   (computation-environment-update (make-computation-environment) x 42)
+	   x)))
 
       (test-eqv #f
-	(let ((x (make-environment-variable))
-	      (env (make-environment)))
-	  (environment-update env x 42)
-	  (environment-ref env x)))
-
-      (test-eqv 42
-	(let ((x (make-environment-variable))
-	      (env (make-environment)))
-	  (environment-update! env x 42)
-	  (environment-ref env x)))
-
-      (test-eqv 42
-	(let ((x (make-environment-variable))
-	      (env (make-environment)))
-	  (environment-update! env x 42)
-	  (environment-update env x 10)
-	  (environment-ref env x)))
+	(let ((x (make-computation-environment-variable))
+	      (y (make-computation-environment-variable)))
+	  (computation-environment-ref
+	   (computation-environment-update (make-computation-environment) x 42)
+	   y)))
 
       (test-eqv #f
-	(let ((x (make-environment-variable))
-	      (env (make-environment)))
-	  (environment-update! (environment-update env x 10) x 42)
-	  (environment-ref env x)))
+	(let ((x (make-computation-environment-variable))
+	      (env (make-computation-environment)))
+	  (computation-environment-update env x 42)
+	  (computation-environment-ref env x)))
 
       (test-eqv 42
-	(let ((x (make-environment-variable))
-	      (y (make-environment-variable))
-	      (env (make-environment)))
-	  (environment-update! (environment-update env y 10) x 42)
-	  (environment-ref env x)))
+	(let ((x (make-computation-environment-variable))
+	      (env (make-computation-environment)))
+	  (computation-environment-update! env x 42)
+	  (computation-environment-ref env x)))
 
       (test-eqv 42
-	(let* ((x (make-environment-variable))
-	       (env (environment-update (make-environment) x 42))
-	       (copy (environment-copy env)))
-	  (environment-update! env x 10)
-	  (environment-ref copy x)))
+	(let ((x (make-computation-environment-variable))
+	      (env (make-computation-environment)))
+	  (computation-environment-update! env x 42)
+	  (computation-environment-update env x 10)
+	  (computation-environment-ref env x)))
+
+      (test-eqv #f
+	(let ((x (make-computation-environment-variable))
+	      (env (make-computation-environment)))
+	  (computation-environment-update!
+	   (computation-environment-update env x 10) x 42)
+	  (computation-environment-ref env x)))
+
+      (test-eqv 42
+	(let ((x (make-computation-environment-variable))
+	      (y (make-computation-environment-variable))
+	      (env (make-computation-environment)))
+	  (computation-environment-update!
+	   (computation-environment-update env y 10) x 42)
+	  (computation-environment-ref env x)))
+
+      (test-eqv 42
+	(let* ((x (make-computation-environment-variable))
+	       (env (computation-environment-update
+		     (make-computation-environment) x 42))
+	       (copy (computation-environment-copy env)))
+	  (computation-environment-update! env x 10)
+	  (computation-environment-ref copy x)))
 
       (test-eqv #f
 	(let ((flag #f))
@@ -96,115 +102,123 @@
 	  flag))
 
       (test-eqv 42
-	(run (make-computation
-	      (lambda (compute)
-		42))))
+	(computation-run (make-computation
+			  (lambda (compute)
+			    42))))
 
       (test-eqv 42
-	(run (make-computation
-	      (lambda (compute)
-		(compute (pure 42))))))
+	(computation-run (make-computation
+			  (lambda (compute)
+			    (compute (computation-pure 42))))))
 
       (test-equal '(10 42)
 	(call-with-values
-	    (lambda () (run (make-computation
-			     (lambda (compute)
-			       (compute (pure 10 42))))))
+	    (lambda ()
+	      (computation-run (make-computation
+				(lambda (compute)
+				  (compute (computation-pure 10 42))))))
 	  list))
 
       (test-equal '(42 (b a))
 	(let* ((acc '())
 	       (result
-		(run (each (make-computation
-			    (lambda (compute)
-			      (set! acc (cons 'a acc))))
-			   (make-computation
-			    (lambda (compute)
-			      (set! acc (cons 'b acc))
-			      42))))))
+		(computation-run (computation-each (make-computation
+						    (lambda (compute)
+						      (set! acc (cons 'a acc))))
+						   (make-computation
+						    (lambda (compute)
+						      (set! acc (cons 'b acc))
+						      42))))))
 	  (list result acc)))
 
       (test-equal '(42 (b a))
 	(let* ((acc '())
 	       (result
-		(run (each-in-list
-		      (list (make-computation
-			     (lambda (compute)
-			       (set! acc (cons 'a acc))))
-			    (make-computation
-			     (lambda (compute)
-			       (set! acc (cons 'b acc))
-			       42)))))))
+		(computation-run (computation-each-in-list
+				  (list (make-computation
+					 (lambda (compute)
+					   (set! acc (cons 'a acc))))
+					(make-computation
+					 (lambda (compute)
+					   (set! acc (cons 'b acc))
+					   42)))))))
 	  (list result acc)))
 
       (test-equal 83
-	(run (bind (pure 42)
-		   (lambda (x)
-		     (pure (* x 2)))
-		   (lambda (x)
-		     (pure (- x 1))))))
+	(computation-run (computation-bind (computation-pure 42)
+			   (lambda (x)
+			     (computation-pure (* x 2)))
+			   (lambda (x)
+			     (computation-pure (- x 1))))))
 
       (test-equal (list 42 84)
-	(run (sequence (list (pure 42)
-			     (pure 84)))))
+	(computation-run (computation-sequence (list (computation-pure 42)
+						     (computation-pure 84)))))
 
 
       (test-equal '(42 #f)
-	(let ((x (make-environment-variable)))
-	  (run (make-computation
-		(lambda (compute)
-		  (let ((a (compute
-			    (local (lambda (env)
-				     (environment-update env x 42))
-			      (bind (ask)
-				    (lambda (env)
-				      (pure (environment-ref env x))))))))
-		    (list a (environment-ref (compute (ask)) x))))))))
+	(let ((x (make-computation-environment-variable)))
+	  (computation-run
+	   (make-computation
+	    (lambda (compute)
+	      (let ((a (compute
+			(computation-local
+			    (lambda (env)
+			      (computation-environment-update env x 42))
+			  (computation-bind (computation-ask)
+			    (lambda (env)
+			      (computation-pure
+			       (computation-environment-ref env x))))))))
+		(list a (computation-environment-ref
+			 (compute (computation-ask)) x))))))))
 
       (test-eqv 42
-	(let ((x (make-environment-variable)))
-	  (run (with ((x 42))
-		 (fn ((y x))
-		   (pure y))))))
+	(let ((x (make-computation-environment-variable)))
+	  (computation-run (computation-with ((x 42))
+			     (computation-fn ((y x))
+			       (computation-pure y))))))
 
       (test-eqv #f
-	(let ((x (make-environment-variable)))
-	  (run (each (with ((x 42))
-		       (fn ((y x))
-			 (pure y)))
-		     (fn ((y x))
-		       (pure y))))))
+	(let ((x (make-computation-environment-variable)))
+	  (computation-run (computation-each (computation-with ((x 42))
+					       (computation-fn ((y x))
+						 (computation-pure y)))
+					     (computation-fn ((y x))
+					       (computation-pure y))))))
 
       (test-eqv 42
-	(let ((x (make-environment-variable)))
-	  (run (each (with! (x 42))
-		     (fn ((y x))
-		       (pure y))))))
+	(let ((x (make-computation-environment-variable)))
+	  (computation-run (computation-each (computation-with! (x 42))
+					     (computation-fn ((y x))
+					       (computation-pure y))))))
 
       (test-eqv #f
-	(let ((x (make-environment-variable)))
-	  (run (forked (with! (x 42))
-		       (fn ((y x))
-			 (pure y))))))
+	(let ((x (make-computation-environment-variable)))
+	  (computation-run (computation-forked (computation-with! (x 42))
+					       (computation-fn ((y x))
+						 (computation-pure y))))))
 
       (test-equal (list #f 2)
-	(let ((x (make-environment-variable)))
-	  (run (bind/forked (each (with! (x 42))
-				  (pure 2))
-			    (lambda (z)
-			      (fn ((y x))
-				(pure (list y z))))))))
+	(let ((x (make-computation-environment-variable)))
+	  (computation-run
+	   (computation-bind/forked (computation-each
+				      (computation-with! (x 42))
+				      (computation-pure 2))
+				    (lambda (z)
+				      (computation-fn ((y x))
+					(computation-pure (list y z))))))))
 
       (test-eqv 42
-	(run (with ((default-computation pure))
-	       42)))
+	(computation-run
+	 (computation-with ((default-computation computation-pure))
+	   42)))
 
 
       (test-eqv 42
-	(let ((x (make-environment-variable)))
-	  (run (with ((x 10))
-		 (with ((x 42))
-		   (fn ((x x))
-		     (pure x)))))))
+	(let ((x (make-computation-environment-variable)))
+	  (computation-run (computation-with ((x 10))
+			     (computation-with ((x 42))
+			       (computation-fn ((x x))
+				 (computation-pure x)))))))
 
       (test-end))))

--- a/srfi/165/test.sld
+++ b/srfi/165/test.sld
@@ -182,6 +182,14 @@
 		       (fn ((y x))
 			 (pure y))))))
 
+      (test-equal (list #f 2)
+	(let ((x (make-environment-variable)))
+	  (run (bind/forked (each (with! (x 42))
+				  (pure 2))
+			    (lambda (z)
+			      (fn ((y x))
+				(pure (list y z))))))))
+
       (test-eqv 42
 	(run (with ((default-computation pure))
 	       42)))

--- a/srfi/165/test.sld
+++ b/srfi/165/test.sld
@@ -28,6 +28,8 @@
 	  (srfi 165))
   (begin
     (define (run-tests)
+      (define-computation-type make-environment run z w)
+      
       (test-begin "SRFI 165")
 
       (test-assert (not (eqv? (make-computation-environment-variable)
@@ -35,21 +37,37 @@
 
       (test-assert (make-computation-environment))
 
+      (test-assert (make-environment))
+      
       (test-eqv #f
 	(let ((x (make-computation-environment-variable)))
 	  (computation-environment-ref (make-computation-environment) x)))
 
+      (test-eqv #f
+	(computation-environment-ref (make-environment) z))
+      
       (test-eqv 42
 	(let ((x (make-computation-environment-variable)))
 	  (computation-environment-ref
 	   (computation-environment-update (make-computation-environment) x 42)
 	   x)))
 
+      (test-eqv 42
+	(computation-environment-ref
+	 (computation-environment-update (make-environment) z 42)
+	 z))
+
       (test-eqv #f
 	(let ((x (make-computation-environment-variable))
 	      (y (make-computation-environment-variable)))
 	  (computation-environment-ref
 	   (computation-environment-update (make-computation-environment) x 42)
+	   y)))
+
+      (test-eqv #f
+	(let ((y (make-computation-environment-variable)))
+	  (computation-environment-ref
+	   (computation-environment-update (make-environment) z 42)
 	   y)))
 
       (test-eqv #f
@@ -65,18 +83,35 @@
 	  (computation-environment-ref env x)))
 
       (test-eqv 42
+	(let ((env (make-environment)))
+	  (computation-environment-update! env z 42)
+	  (computation-environment-ref env z)))
+
+      (test-eqv 42
 	(let ((x (make-computation-environment-variable))
 	      (env (make-computation-environment)))
 	  (computation-environment-update! env x 42)
 	  (computation-environment-update env x 10)
 	  (computation-environment-ref env x)))
 
+      (test-eqv 42
+	(let ((env (make-environment)))
+	  (computation-environment-update! env z 42)
+	  (computation-environment-update env z 10)
+	  (computation-environment-ref env z)))
+      
       (test-eqv #f
 	(let ((x (make-computation-environment-variable))
 	      (env (make-computation-environment)))
 	  (computation-environment-update!
 	   (computation-environment-update env x 10) x 42)
 	  (computation-environment-ref env x)))
+
+      (test-eqv #f
+	(let ((env (make-environment)))
+	  (computation-environment-update!
+	   (computation-environment-update env z 10) z 42)
+	  (computation-environment-ref env z)))
 
       (test-eqv 42
 	(let ((x (make-computation-environment-variable))
@@ -87,6 +122,12 @@
 	  (computation-environment-ref env x)))
 
       (test-eqv 42
+	(let ((env (make-environment)))
+	  (computation-environment-update!
+	   (computation-environment-update env w 10) z 42)
+	  (computation-environment-ref env z)))
+
+      (test-eqv 42
 	(let* ((x (make-computation-environment-variable))
 	       (env (computation-environment-update
 		     (make-computation-environment) x 42))
@@ -94,6 +135,13 @@
 	  (computation-environment-update! env x 10)
 	  (computation-environment-ref copy x)))
 
+      (test-eqv 42
+	(let* ((env (computation-environment-update
+		     (make-environment) z 42))
+	       (copy (computation-environment-copy env)))
+	  (computation-environment-update! env z 10)
+	  (computation-environment-ref copy z)))
+      
       (test-eqv #f
 	(let ((flag #f))
 	  (make-computation
@@ -177,6 +225,11 @@
 	  (computation-run (computation-with ((x 42))
 			     (computation-fn ((y x))
 			       (computation-pure y))))))
+
+      (test-eqv 42
+	(run (computation-with ((z 42))
+	       (computation-fn ((y z))
+		 (computation-pure y)))))
 
       (test-eqv 42
 	(let ((x (make-computation-environment-variable)))

--- a/srfi/165/test.sld
+++ b/srfi/165/test.sld
@@ -52,6 +52,13 @@
 	   (computation-environment-update (make-computation-environment) x 42)
 	   x)))
 
+      (test-eqv 10
+	(let ((x (make-computation-environment-variable))
+	      (y (make-computation-environment-variable)))
+	  (computation-environment-ref
+	   (computation-environment-update (make-computation-environment) x 42 y 10)
+	   y)))
+
       (test-eqv 42
 	(computation-environment-ref
 	 (computation-environment-update (make-environment) z 42)
@@ -280,4 +287,16 @@
 			       (computation-fn ((x x))
 				 (computation-pure x)))))))
 
+      (test-equal (list 10 42)
+	(let ((x (make-computation-environment-variable))
+	      (y (make-computation-environment-variable)))
+	  (computation-run (computation-with ((x 10) (y 42))
+			     (computation-fn (x y)
+			       (computation-pure (list x y)))))))
+      
+      (test-equal (list 10 42)
+	(run (computation-with ((z 10) (w 42))
+	       (computation-fn (z w)
+		 (computation-pure (list z w))))))
+      
       (test-end))))

--- a/srfi/165/test.sld
+++ b/srfi/165/test.sld
@@ -32,29 +32,33 @@
       
       (test-begin "SRFI 165")
 
-      (test-assert (not (eqv? (make-computation-environment-variable)
-			      (make-computation-environment-variable))))
-
+      (test-assert (not (eqv? (make-computation-environment-variable 'x #f #f)
+			      (make-computation-environment-variable 'x #f #f))))
+      
       (test-assert (make-computation-environment))
 
       (test-assert (make-environment))
       
       (test-eqv #f
-	(let ((x (make-computation-environment-variable)))
+	(let ((x (make-computation-environment-variable 'x #f #f)))
+	  (computation-environment-ref (make-computation-environment) x)))
+
+      (test-eqv 42
+	(let ((x (make-computation-environment-variable 'x 42 #f)))
 	  (computation-environment-ref (make-computation-environment) x)))
 
       (test-eqv #f
 	(computation-environment-ref (make-environment) z))
       
       (test-eqv 42
-	(let ((x (make-computation-environment-variable)))
+	(let ((x (make-computation-environment-variable 'x #f #f)))
 	  (computation-environment-ref
 	   (computation-environment-update (make-computation-environment) x 42)
 	   x)))
 
       (test-eqv 10
-	(let ((x (make-computation-environment-variable))
-	      (y (make-computation-environment-variable)))
+	(let ((x (make-computation-environment-variable 'x #f #f))
+	      (y (make-computation-environment-variable 'y #f #f)))
 	  (computation-environment-ref
 	   (computation-environment-update (make-computation-environment) x 42 y 10)
 	   y)))
@@ -65,26 +69,26 @@
 	 z))
 
       (test-eqv #f
-	(let ((x (make-computation-environment-variable))
-	      (y (make-computation-environment-variable)))
+	(let ((x (make-computation-environment-variable 'x #f #f))
+	      (y (make-computation-environment-variable 'y #f #f)))
 	  (computation-environment-ref
 	   (computation-environment-update (make-computation-environment) x 42)
 	   y)))
 
       (test-eqv #f
-	(let ((y (make-computation-environment-variable)))
+	(let ((y (make-computation-environment-variable 'y #f #f)))
 	  (computation-environment-ref
 	   (computation-environment-update (make-environment) z 42)
 	   y)))
 
       (test-eqv #f
-	(let ((x (make-computation-environment-variable))
+	(let ((x (make-computation-environment-variable 'x #f #f))
 	      (env (make-computation-environment)))
 	  (computation-environment-update env x 42)
 	  (computation-environment-ref env x)))
 
       (test-eqv 42
-	(let ((x (make-computation-environment-variable))
+	(let ((x (make-computation-environment-variable 'x #f #f))
 	      (env (make-computation-environment)))
 	  (computation-environment-update! env x 42)
 	  (computation-environment-ref env x)))
@@ -95,7 +99,7 @@
 	  (computation-environment-ref env z)))
 
       (test-eqv 42
-	(let ((x (make-computation-environment-variable))
+	(let ((x (make-computation-environment-variable 'x #f #f))
 	      (env (make-computation-environment)))
 	  (computation-environment-update! env x 42)
 	  (computation-environment-update env x 10)
@@ -108,7 +112,7 @@
 	  (computation-environment-ref env z)))
       
       (test-eqv #f
-	(let ((x (make-computation-environment-variable))
+	(let ((x (make-computation-environment-variable 'x #f #f))
 	      (env (make-computation-environment)))
 	  (computation-environment-update!
 	   (computation-environment-update env x 10) x 42)
@@ -121,8 +125,8 @@
 	  (computation-environment-ref env z)))
 
       (test-eqv 42
-	(let ((x (make-computation-environment-variable))
-	      (y (make-computation-environment-variable))
+	(let ((x (make-computation-environment-variable 'x #f #f))
+	      (y (make-computation-environment-variable 'y #f #f))
 	      (env (make-computation-environment)))
 	  (computation-environment-update!
 	   (computation-environment-update env y 10) x 42)
@@ -135,7 +139,7 @@
 	  (computation-environment-ref env z)))
 
       (test-eqv 42
-	(let* ((x (make-computation-environment-variable))
+	(let* ((x (make-computation-environment-variable 'x #f #f))
 	       (env (computation-environment-update
 		     (make-computation-environment) x 42))
 	       (copy (computation-environment-copy env)))
@@ -212,7 +216,7 @@
 
 
       (test-equal '(42 #f)
-	(let ((x (make-computation-environment-variable)))
+	(let ((x (make-computation-environment-variable 'x #f #f)))
 	  (computation-run
 	   (make-computation
 	    (lambda (compute)
@@ -228,7 +232,7 @@
 			 (compute (computation-ask)) x))))))))
 
       (test-eqv 42
-	(let ((x (make-computation-environment-variable)))
+	(let ((x (make-computation-environment-variable 'x #f #f)))
 	  (computation-run (computation-with ((x 42))
 			     (computation-fn ((y x))
 			       (computation-pure y))))))
@@ -239,13 +243,13 @@
 		 (computation-pure y)))))
 
       (test-eqv 42
-	(let ((x (make-computation-environment-variable)))
+	(let ((x (make-computation-environment-variable 'x #f #f)))
 	  (computation-run (computation-with ((x 42))
 			     (computation-fn (x)
 			       (computation-pure x))))))
 
       (test-eqv #f
-	(let ((x (make-computation-environment-variable)))
+	(let ((x (make-computation-environment-variable 'x #f #f)))
 	  (computation-run (computation-each (computation-with ((x 42))
 					       (computation-fn ((y x))
 						 (computation-pure y)))
@@ -253,19 +257,19 @@
 					       (computation-pure y))))))
 
       (test-eqv 42
-	(let ((x (make-computation-environment-variable)))
+	(let ((x (make-computation-environment-variable 'x #f #f)))
 	  (computation-run (computation-each (computation-with! (x 42))
 					     (computation-fn ((y x))
 					       (computation-pure y))))))
 
       (test-eqv #f
-	(let ((x (make-computation-environment-variable)))
+	(let ((x (make-computation-environment-variable 'x #f #f)))
 	  (computation-run (computation-forked (computation-with! (x 42))
 					       (computation-fn ((y x))
 						 (computation-pure y))))))
 
       (test-equal (list #f 2)
-	(let ((x (make-computation-environment-variable)))
+	(let ((x (make-computation-environment-variable 'x #f #f)))
 	  (computation-run
 	   (computation-bind/forked (computation-each
 				      (computation-with! (x 42))
@@ -281,15 +285,15 @@
 
 
       (test-eqv 42
-	(let ((x (make-computation-environment-variable)))
+	(let ((x (make-computation-environment-variable 'x #f #f)))
 	  (computation-run (computation-with ((x 10))
 			     (computation-with ((x 42))
 			       (computation-fn ((x x))
 				 (computation-pure x)))))))
 
       (test-equal (list 10 42)
-	(let ((x (make-computation-environment-variable))
-	      (y (make-computation-environment-variable)))
+	(let ((x (make-computation-environment-variable 'x #f #f))
+	      (y (make-computation-environment-variable 'y #f #f)))
 	  (computation-run (computation-with ((x 10) (y 42))
 			     (computation-fn (x y)
 			       (computation-pure (list x y)))))))
@@ -298,5 +302,11 @@
 	(run (computation-with ((z 10) (w 42))
 	       (computation-fn (z w)
 		 (computation-pure (list z w))))))
+
+      (test-equal (list 10 42)
+	(let ()
+	  (define-computation-type make-environment run (x 10) (y 42 "immutable"))
+	  (run (computation-fn (x y)
+		 (computation-pure (list x y))))))
       
       (test-end))))

--- a/srfi/165/test.sld
+++ b/srfi/165/test.sld
@@ -80,7 +80,7 @@
 	      (env (make-environment)))
 	  (environment-update! (environment-update env y 10) x 42)
 	  (environment-ref env x)))
-      
+
       (test-eqv 42
 	(let* ((x (make-environment-variable))
 	       (env (environment-update (make-environment) x 42))
@@ -94,7 +94,7 @@
 	   (lambda (compute)
 	     (set! flag #t)))
 	  flag))
-      
+
       (test-eqv 42
 	(run (make-computation
 	      (lambda (compute)
@@ -103,15 +103,15 @@
       (test-eqv 42
 	(run (make-computation
 	      (lambda (compute)
-		(compute (return 42))))))
+		(compute (pure 42))))))
 
       (test-equal '(10 42)
 	(call-with-values
 	    (lambda () (run (make-computation
 			     (lambda (compute)
-			       (compute (return 10 42))))))
+			       (compute (pure 10 42))))))
 	  list))
-      
+
       (test-equal '(42 (b a))
 	(let* ((acc '())
 	       (result
@@ -125,11 +125,11 @@
 	  (list result acc)))
 
       (test-equal 83
-	(run (bind (return 42)
+	(run (bind (pure 42)
 		   (lambda (x)
-		     (return (* x 2)))
+		     (pure (* x 2)))
 		   (lambda (x)
-		     (return (- x 1))))))
+		     (pure (- x 1))))))
 
       (test-equal '(42 #f)
 	(let ((x (make-environment-variable)))
@@ -140,37 +140,37 @@
 				     (environment-update env x 42))
 			      (bind (ask)
 				    (lambda (env)
-				      (return (environment-ref env x))))))))
+				      (pure (environment-ref env x))))))))
 		    (list a (environment-ref (compute (ask)) x))))))))
 
       (test-eqv 42
 	(let ((x (make-environment-variable)))
 	  (run (with ((x 42))
 		 (fn ((y x))
-		   (return y))))))
+		   (pure y))))))
 
       (test-eqv #f
 	(let ((x (make-environment-variable)))
 	  (run (sequence (with ((x 42))
 			   (fn ((y x))
-			     (return y)))
+			     (pure y)))
 			 (fn ((y x))
-			   (return y))))))
+			   (pure y))))))
 
       (test-eqv 42
 	(let ((x (make-environment-variable)))
 	  (run (sequence (with! (x 42))
 			 (fn ((y x))
-			   (return y))))))
+			   (pure y))))))
 
       (test-eqv #f
 	(let ((x (make-environment-variable)))
 	  (run (forked (with! (x 42))
 		       (fn ((y x))
-			 (return y))))))
+			 (pure y))))))
 
       (test-eqv 42
-	(run (with ((default-computation return))
+	(run (with ((default-computation pure))
 	       42)))
 
 
@@ -179,6 +179,6 @@
 	  (run (with ((x 10))
 		 (with ((x 42))
 		   (fn ((x x))
-		     (return x))))))) 
-      
+		     (pure x)))))))
+
       (test-end))))

--- a/srfi/165/test.sld
+++ b/srfi/165/test.sld
@@ -124,6 +124,19 @@
 			      42))))))
 	  (list result acc)))
 
+      (test-equal '(42 (b a))
+	(let* ((acc '())
+	       (result
+		(run (each-in-list
+		      (list (make-computation
+			     (lambda (compute)
+			       (set! acc (cons 'a acc))))
+			    (make-computation
+			     (lambda (compute)
+			       (set! acc (cons 'b acc))
+			       42)))))))
+	  (list result acc)))
+
       (test-equal 83
 	(run (bind (pure 42)
 		   (lambda (x)

--- a/srfi/165/test.sld
+++ b/srfi/165/test.sld
@@ -115,13 +115,13 @@
       (test-equal '(42 (b a))
 	(let* ((acc '())
 	       (result
-		(run (sequence (make-computation
-				(lambda (compute)
-				  (set! acc (cons 'a acc))))
-			       (make-computation
-				(lambda (compute)
-				  (set! acc (cons 'b acc))
-				  42))))))
+		(run (each (make-computation
+			    (lambda (compute)
+			      (set! acc (cons 'a acc))))
+			   (make-computation
+			    (lambda (compute)
+			      (set! acc (cons 'b acc))
+			      42))))))
 	  (list result acc)))
 
       (test-equal 83
@@ -151,17 +151,17 @@
 
       (test-eqv #f
 	(let ((x (make-environment-variable)))
-	  (run (sequence (with ((x 42))
-			   (fn ((y x))
-			     (pure y)))
-			 (fn ((y x))
-			   (pure y))))))
+	  (run (each (with ((x 42))
+		       (fn ((y x))
+			 (pure y)))
+		     (fn ((y x))
+		       (pure y))))))
 
       (test-eqv 42
 	(let ((x (make-environment-variable)))
-	  (run (sequence (with! (x 42))
-			 (fn ((y x))
-			   (pure y))))))
+	  (run (each (with! (x 42))
+		     (fn ((y x))
+		       (pure y))))))
 
       (test-eqv #f
 	(let ((x (make-environment-variable)))

--- a/srfi/165/test.sld
+++ b/srfi/165/test.sld
@@ -144,6 +144,11 @@
 		   (lambda (x)
 		     (pure (- x 1))))))
 
+      (test-equal (list 42 84)
+	(run (sequence (list (pure 42)
+			     (pure 84)))))
+
+
       (test-equal '(42 #f)
 	(let ((x (make-environment-variable)))
 	  (run (make-computation


### PR DESCRIPTION
The following changes have been incorporated since the first draft:

1. The `return` procedure is now named `pure`.
2. The `sequence` procedure is now named `each` as in SRFI 159/166.
3. `each-in-list` added for use in SRFI 159/166.
4.  `bind/forked` added; it is like bind but the first argument is executed in a copy of the environment.
5. `sequence` newly added, which maps a list of monadic values into a monadic list of values.
6. The exported identifiers are now prefixed with `computation-`.
7. The section of predefined environment variables has been made clearer.
8. Mentioning of SRFI 166.
9. `computation-fn` now compatible with SRFI 166.
10. Fast-access environment variables can now be predefined using `define-computation-type`.
11. `computation-environment-update` can now update more than one variable at once.
12. Environment variables can now take default values (for compatibility with SRFI 166) and can be marked immutable.
