### PR TITLE
Construct hash-table with make-hash-table for mutability

### DIFF
--- a/srfi/165.scm
+++ b/srfi/165.scm
@@ -82,7 +82,7 @@
        ...
        (define (make-environment)
 	 (let ((env (make-vector (+ n 2))))
-	   (environment-set-global! env (hash-table variable-comparator))
+	   (environment-set-global! env (make-hash-table variable-comparator))
 	   (environment-set-local! env (mapping variable-comparator))
 	   (vector-set! env (+ i 2) (box e))
 	   ...


### PR DESCRIPTION
We want a mutable table here.  hash-table creates an immutable table if supported by (srfi 125).
